### PR TITLE
Fixed compile error with current Arduino (>1.0)

### DIFF
--- a/jarduino.core/src/main/arduino/JArduino/JArduino.cpp
+++ b/jarduino.core/src/main/arduino/JArduino/JArduino.cpp
@@ -17,7 +17,11 @@
  */
 
 // include core Wiring API
-#include "WProgram.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include "Arduino.h"
+#else
+	#include "WProgram.h"
+#endif
 
 // include this library's description file
 #include "JArduino.h"

--- a/jarduino.core/src/main/arduino/JArduino/JArduino.h
+++ b/jarduino.core/src/main/arduino/JArduino/JArduino.h
@@ -21,7 +21,12 @@
 #define JArduino_h
 
 // include types & constants of Wiring core API
-#include "WConstants.h"
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include "Arduino.h"
+#else
+	#include "WConstants.h"
+#endif
+
 #undef abs
 #undef round
 


### PR DESCRIPTION
WProgram.h and WConstants.h were deprecated in favor of Arduino.h
(see also
http://stackoverflow.com/questions/8593442/arduino-custom-library-error-when-compiling-delay)