### PR TITLE
Add built in digital states

### DIFF
--- a/jarduino.core/src/main/java/org/sintef/jarduino/JArduino.java
+++ b/jarduino.core/src/main/java/org/sintef/jarduino/JArduino.java
@@ -51,6 +51,9 @@ public abstract class JArduino extends AbstractJArduino {
     public JArduino(String id, ProtocolConfiguration prot) {
         super(id, JArduinoCom.Serial, prot); //Serial by default
     }
+	
+    private final DigitalState LOW = DigitalState.LOW;
+    private final DigitalState HIGH = DigitalState.HIGH;
 
     @Override
     protected void receiveInterruptNotification(InterruptPin interrupt) {


### PR DESCRIPTION
By having built in digital states in the abstract Jarduino class, it will allow for users to more easily switch from the C/C++ to Java.