### PR TITLE
problem with constructor of cpp and h files

### DIFF
--- a/jarduino.core/src/main/arduino/JArduino/JArduino.cpp
+++ b/jarduino.core/src/main/arduino/JArduino/JArduino.cpp
@@ -33,7 +33,7 @@ JArduino::JArduino() {
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
-void JArduino::init_JArduino(uint16_t baud = 9600) {
+void JArduino::init_JArduino() {
 	// init the serial port
 	Serial.begin(baud);
 }

--- a/jarduino.core/src/main/arduino/JArduino/JArduino.h
+++ b/jarduino.core/src/main/arduino/JArduino/JArduino.h
@@ -111,7 +111,7 @@ class JArduino
 	// Constructor
     JArduino();
 	// Standard init and pool operations to be called in setup and loop
-	void init_JArduino(uint16_t baud);
+	void init_JArduino();
 	void poll_JArduino();
 	// Operations for sending all messages
     void senddigitalReadResult(uint8_t value);


### PR DESCRIPTION
there was a problem with the Parameters of the constructor of the JArduino.cpp and the JArduino.h

In the examples the Baudrate was passed to the c++ and Header file, but there isn't a constructor with such properties
